### PR TITLE
File path bug fixes

### DIFF
--- a/isanlp_rst/dmrst_parser/predictor.py
+++ b/isanlp_rst/dmrst_parser/predictor.py
@@ -44,7 +44,7 @@ class Predictor:
         if self.mode == 'local':
             self.model_file = os.path.join(model_dir, _file_model)
             self.config_path = os.path.join(model_dir, _file_config)
-            self.relation_table = open(_file_relation_table, 'r').read().splitlines()
+            self.relation_table = open(os.path.join(model_dir, _file_relation_table), 'r').read().splitlines()
 
         elif self.mode == 'hf':
             self.hf_model_name = hf_model_name

--- a/isanlp_rst/rstviewer/rstweb_sql.py
+++ b/isanlp_rst/rstviewer/rstweb_sql.py
@@ -20,7 +20,7 @@ import tempfile
 from .rstweb_reader import *  # noqa: F401,F403  (re-exported API)
 
 
-with tempfile.NamedTemporaryFile(dir="./tmp", delete=False) as tmpfile:
+with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
     DBPATH = tmpfile.name
 
 

--- a/isanlp_rst/rstviewer/rstweb_sql.py
+++ b/isanlp_rst/rstviewer/rstweb_sql.py
@@ -20,7 +20,7 @@ import tempfile
 from .rstweb_reader import *  # noqa: F401,F403  (re-exported API)
 
 
-with tempfile.NamedTemporaryFile(dir="/tmp", delete=False) as tmpfile:
+with tempfile.NamedTemporaryFile(dir="./tmp", delete=False) as tmpfile:
     DBPATH = tmpfile.name
 
 


### PR DESCRIPTION
Previously the relation table was loaded from the filename without joining it to the model_dir path. This required the relation table to be in the current working directory and not in model_dir with the other model files.